### PR TITLE
DAC6-2583: Fix SessionRepositorySpec it test

### DIFF
--- a/it/repositories/SessionRepositorySpec.scala
+++ b/it/repositories/SessionRepositorySpec.scala
@@ -12,6 +12,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
+import java.time.temporal.ChronoUnit
 import java.time.{Clock, Instant, ZoneId}
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -24,7 +25,7 @@ class SessionRepositorySpec
     with OptionValues
     with MockitoSugar {
 
-  private val instant = Instant.now
+  private val instant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
   private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
 
   private val userAnswers = UserAnswers("id", Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))


### PR DESCRIPTION
This fixes the failing SessionRepositorySpec it test