### PR TITLE
DAC6-2979: Added custom styles for vertical alignment on error table

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -70,6 +70,16 @@ body:not(.js-enabled) .js-enabled {
   word-wrap: anywhere;
 }
 
-.cbc-file-rejected-table td > p:last-child {
+.cbc-file-rejected-table .govuk-body,
+.cbc-file-rejected-table .govuk-list {
+  margin-bottom: 0.4em;
+}
+
+.cbc-file-rejected-table .doc-ref-ids .govuk-body {
+  margin-bottom: 1em;
+}
+
+.cbc-file-rejected-table td > .govuk-body:last-child,
+.cbc-file-rejected-table td > .govuk-list:last-child {
   margin-bottom: 0;
 }

--- a/app/views/components/FileRejectedTable.scala.html
+++ b/app/views/components/FileRejectedTable.scala.html
@@ -37,7 +37,7 @@
             val errCode = error.errorCode
             Seq(
                 TableRow(Text(errCode.replaceAll("CBC Error Code ", "")), attributes = Map("id" -> s"code_$errCode")),
-                TableRow(HtmlContent(getDocRefId(error.docRefIds)), attributes = Map("id" -> s"docRefId_$errCode")),
+                TableRow(HtmlContent(getDocRefId(error.docRefIds)), attributes = Map("id" -> s"docRefId_$errCode"), classes="doc-ref-ids"),
                 TableRow(HtmlContent(getErrorDescription(error.errorCode)), attributes = Map("id" -> s"errorMessage_$errCode"))
             )
         }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 


### PR DESCRIPTION
Updated styling for the business rule error table.

Overriding the default vertical spacing to make the page display with the same margins as the prototype.

Screenshot showing spacing on both the document ref ids and the html error messages on the frontend as compared to the prototype:

<img width="2137" alt="Screenshot showing margin updates" src="https://github.com/hmrc/country-by-country-reporting-frontend/assets/238270/00432a04-b6ae-4c17-bed6-189cee4d828a">
