### PR TITLE
DAC6-3032: css override for .govuk-summary-list__value

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -83,3 +83,7 @@ body:not(.js-enabled) .js-enabled {
 .cbc-file-rejected-table td > .govuk-list:last-child {
   margin-bottom: 0;
 }
+
+.govuk-summary-list__value {
+      width: 50%;
+  }


### PR DESCRIPTION
<img width="1190" alt="image" src="https://github.com/hmrc/country-by-country-reporting-frontend/assets/77161245/7802f54b-ff5c-4054-a8cd-f983518f985f">
