### PR TITLE
DAC6-3300: Correct status message for 'Accepted'.

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -292,7 +292,7 @@ cssColour.Accepted = green
 cssColour.Pending = yellow
 cssColour.Problem = purple
 status.Rejected = Failed
-status.Accepted = PASSED
+status.Accepted = Passed
 status.Pending = Pending
 status.Problem = Problem
 

--- a/test/viewmodels/FileCheckViewModelSpec.scala
+++ b/test/viewmodels/FileCheckViewModelSpec.scala
@@ -38,7 +38,7 @@ class FileCheckViewModelSpec extends SpecBase {
 
       val expectedSummary = Seq(
         SummaryListRow(Key(Text("File ID (MessageRefId)")), Value(Text("MessageRefId123")), "", None),
-        SummaryListRow(Key(Text("Result of automatic checks")), Value(HtmlContent("<strong class='govuk-tag govuk-tag--green'>PASSED</strong>")), "", None)
+        SummaryListRow(Key(Text("Result of automatic checks")), Value(HtmlContent("<strong class='govuk-tag govuk-tag--green'>Passed</strong>")), "", None)
       )
 
       FileCheckViewModel.createFileSummary("MessageRefId123", "Accepted")(messages(app)) mustBe expectedSummary


### PR DESCRIPTION
Changed the value of 'status.Accepted' from 'PASSED' to 'Passed' to ensure consistency with other status messages and improve readability. This update ensures that all status messages follow the same capitalization style.