### PR TITLE
DAC6-3648: Migrate to HttpClientV2 across connectors

### DIFF
--- a/app/connectors/FileDetailsConnector.scala
+++ b/app/connectors/FileDetailsConnector.scala
@@ -22,16 +22,17 @@ import models.fileDetails.{FileDetails, FileStatus}
 import play.api.Logging
 import uk.gov.hmrc.http.HttpErrorFunctions.is2xx
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class FileDetailsConnector @Inject() (httpClient: HttpClient, config: FrontendAppConfig) extends Logging {
+class FileDetailsConnector @Inject() (httpClient: HttpClientV2, config: FrontendAppConfig) extends Logging {
 
   def getAllFileDetails(subscriptionId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Seq[FileDetails]]] = {
-    val url = s"${config.cbcUrl}/country-by-country-reporting/files/details/$subscriptionId"
-    httpClient.GET[HttpResponse](url).map {
+    val url = url"${config.cbcUrl}/country-by-country-reporting/files/details/$subscriptionId"
+    httpClient.get(url).execute[HttpResponse].map {
       case responseMessage if is2xx(responseMessage.status) =>
         responseMessage.json
           .asOpt[Seq[FileDetails]]
@@ -42,8 +43,8 @@ class FileDetailsConnector @Inject() (httpClient: HttpClient, config: FrontendAp
   }
 
   def getFileDetails(conversationId: ConversationId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[FileDetails]] = {
-    val url = s"${config.cbcUrl}/country-by-country-reporting/files/${conversationId.value}/details"
-    httpClient.GET(url).map {
+    val url = url"${config.cbcUrl}/country-by-country-reporting/files/${conversationId.value}/details"
+    httpClient.get(url).execute[HttpResponse].map {
       case responseMessage if is2xx(responseMessage.status) =>
         responseMessage.json
           .asOpt[FileDetails]
@@ -54,8 +55,8 @@ class FileDetailsConnector @Inject() (httpClient: HttpClient, config: FrontendAp
   }
 
   def getStatus(conversationId: ConversationId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[FileStatus]] = {
-    val url = s"${config.cbcUrl}/country-by-country-reporting/files/${conversationId.value}/status"
-    httpClient.GET(url).map {
+    val url = url"${config.cbcUrl}/country-by-country-reporting/files/${conversationId.value}/status"
+    httpClient.get(url).execute[HttpResponse].map {
       case responseMessage if is2xx(responseMessage.status) =>
         responseMessage.json.asOpt[FileStatus]
       case _ =>

--- a/app/controllers/testOnlyDoNotUseInAppConf/TestProcessEISResponseConnector.scala
+++ b/app/controllers/testOnlyDoNotUseInAppConf/TestProcessEISResponseConnector.scala
@@ -20,15 +20,16 @@ import config.FrontendAppConfig
 import play.api.Logging
 import play.api.http.HeaderNames
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.NodeSeq
 
-class TestProcessEISResponseConnector @Inject() (httpClient: HttpClient, config: FrontendAppConfig)(implicit ec: ExecutionContext) extends Logging {
+class TestProcessEISResponseConnector @Inject() (httpClient: HttpClientV2, config: FrontendAppConfig)(implicit ec: ExecutionContext) extends Logging {
 
-  val submitUrl = s"${config.cbcUrl}/country-by-country-reporting/validation-result"
+  val submitUrl = url"${config.cbcUrl}/country-by-country-reporting/validation-result"
 
   def submitEISResponse(conversationId: String, xmlDocument: NodeSeq): Future[HttpResponse] = {
     implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -38,6 +39,6 @@ class TestProcessEISResponseConnector @Inject() (httpClient: HttpClient, config:
       HeaderNames.AUTHORIZATION -> "Bearer token"
     )
 
-    httpClient.POSTString[HttpResponse](submitUrl, xmlDocument.toString(), headers)
+    httpClient.post(submitUrl).withBody(xmlDocument.toString()).setHeader(headers: _*).execute[HttpResponse]
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -35,7 +35,6 @@ play.filters.enabled += play.filters.csp.CSPFilter
 
 play.http.errorHandler = "handlers.ErrorHandler"
 
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"

--- a/test/helpers/FakeUpscanConnector.scala
+++ b/test/helpers/FakeUpscanConnector.scala
@@ -19,12 +19,13 @@ package helpers
 import config.FrontendAppConfig
 import connectors.UpscanConnector
 import models.upscan._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.client.HttpClientV2
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class FakeUpscanConnector @Inject() (configuration: FrontendAppConfig, httpClient: HttpClient)(implicit ec: ExecutionContext)
+class FakeUpscanConnector @Inject() (configuration: FrontendAppConfig, httpClient: HttpClientV2)(implicit ec: ExecutionContext)
     extends UpscanConnector(configuration, httpClient) {
 
   var statusBuffer: Option[UploadStatus]          = None


### PR DESCRIPTION
Replaced deprecated HttpClient with HttpClientV2 in all connectors to improve API consistency and leverage new features. Updated method calls for HTTP operations such as GET, POST, and added appropriate body handling and headers where necessary.