### PR TITLE
DAC6-3776 | add a FileReference page object to store Upscan id so we …

### DIFF
--- a/app/connectors/UpscanConnector.scala
+++ b/app/connectors/UpscanConnector.scala
@@ -50,7 +50,7 @@ class UpscanConnector @Inject() (configuration: FrontendAppConfig, httpClient: H
     httpClient
       .post(url"$upscanInitiateUrl")
       .withBody(Json.toJson(body))
-      .setHeader(headers.toSeq :+ ("X-Upload-Id" -> uploadId.value): _*)
+      .setHeader(headers.toSeq: _*)
       .execute[PreparedUpload] map {
       _.toUpscanInitiateResponse
     }

--- a/app/controllers/FilePendingChecksController.scala
+++ b/app/controllers/FilePendingChecksController.scala
@@ -21,7 +21,7 @@ import connectors.FileDetailsConnector
 import controllers.actions._
 import models.fileDetails.{FileValidationErrors, Pending, Rejected, RejectedSDES, RejectedSDESVirus, Accepted => FileStatusAccepted}
 import models.{UserAnswers, ValidatedFileData}
-import pages.{ConversationIdPage, UploadIDPage, ValidXMLPage}
+import pages.{ConversationIdPage, FileReferencePage, UploadIDPage, ValidXMLPage}
 import play.api.i18n.Lang.logger
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
@@ -81,7 +81,7 @@ class FilePendingChecksController @Inject() (
     userAnswers.get(ConversationIdPage) match {
       case Some(conversationId) =>
         for {
-          updatedAnswers <- Future.fromTry(userAnswers.remove(UploadIDPage))
+          updatedAnswers <- Future.fromTry(userAnswers.remove(UploadIDPage).flatMap(_.remove(FileReferencePage)))
           _              <- sessionRepository.set(updatedAnswers)
         } yield Ok(view(summary, routes.FilePendingChecksController.onPageLoad().url, conversationId.value, getMinutesToWait(xmlDetails.fileSize), isAgent))
       case _ => Future.successful(InternalServerError(errorView()))

--- a/app/controllers/FileReceivedController.scala
+++ b/app/controllers/FileReceivedController.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.FileDetailsConnector
 import controllers.actions._
 import models.ConversationId
-import pages.UploadIDPage
+import pages.{FileReferencePage, UploadIDPage}
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -64,7 +64,7 @@ class FileReceivedController @Inject() (
               getAgentContactEmails match {
                 case Some(agentContactEmails) =>
                   for {
-                    updatedAnswers <- Future.fromTry(request.userAnswers.remove(UploadIDPage))
+                    updatedAnswers <- Future.fromTry(request.userAnswers.remove(UploadIDPage).flatMap(_.remove(FileReferencePage)))
                     _              <- sessionRepository.set(updatedAnswers)
                   } yield Ok(
                     agentView(
@@ -83,7 +83,7 @@ class FileReceivedController @Inject() (
               }
             case Organisation =>
               for {
-                updatedAnswers <- Future.fromTry(request.userAnswers.remove(UploadIDPage))
+                updatedAnswers <- Future.fromTry(request.userAnswers.remove(UploadIDPage).flatMap(_.remove(FileReferencePage)))
                 _              <- sessionRepository.set(updatedAnswers)
               } yield Ok(
                 view(

--- a/app/controllers/actions/CheckForSubmissionAction.scala
+++ b/app/controllers/actions/CheckForSubmissionAction.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import controllers.routes
 import models.requests.DataRequest
-import pages.{JourneyInProgressPage, UploadIDPage}
+import pages.{FileReferencePage, JourneyInProgressPage, UploadIDPage}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionRefiner, Result}
 
@@ -37,7 +37,7 @@ class CheckForSubmissionActionProvider @Inject() (checkFileSubmission: Boolean)(
 
   override protected def refine[A](request: DataRequest[A]): Future[Either[Result, DataRequest[A]]] =
     if (
-      (checkFileSubmission && request.userAnswers.get(UploadIDPage).isEmpty) ||
+      (checkFileSubmission && request.userAnswers.get(UploadIDPage).isEmpty && request.userAnswers.get(FileReferencePage).isEmpty) ||
       (!checkFileSubmission && request.userAnswers.get(JourneyInProgressPage).isEmpty)
     ) {
       Future.successful(Left(Redirect(routes.InformationSentController.onPageLoad())))

--- a/app/pages/FileReferencePage.scala
+++ b/app/pages/FileReferencePage.scala
@@ -14,23 +14,15 @@
  * limitations under the License.
  */
 
-package models.submission
+package pages
 
-import models.MessageSpecData
-import models.upscan.{Reference, UploadId}
-import play.api.libs.json.{Json, OFormat}
+import models.upscan.Reference
+import play.api.libs.json.JsPath
 
-final case class SubmissionDetails(
-  fileName: String,
-  uploadId: UploadId,
-  enrolmentId: String,
-  fileSize: Long,
-  documentUrl: String,
-  checksum: String,
-  messageSpecData: MessageSpecData,
-  fileReference: Reference
-)
+case object FileReferencePage extends QuestionPage[Reference] {
 
-object SubmissionDetails {
-  implicit val format: OFormat[SubmissionDetails] = Json.format[SubmissionDetails]
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "FileReference"
+
 }

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -21,7 +21,7 @@ import models.agentSubscription._
 import models.fileDetails.{BusinessRuleErrorCode, FileErrors, FileValidationErrors, RecordError}
 import models.submission.SubmissionDetails
 import models.subscription._
-import models.upscan.UploadId
+import models.upscan.{Reference, UploadId}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -53,6 +53,12 @@ trait ModelGenerators {
     for {
       orgName <- nonEmptyString
     } yield AgentDetails(orgName)
+  }
+
+  implicit val arbitraryReference: Arbitrary[Reference] = Arbitrary {
+    for {
+      str <- nonEmptyString
+    } yield Reference(str)
   }
 
   implicit val arbitraryContactInformation: Arbitrary[ContactInformation] = Arbitrary {
@@ -197,13 +203,14 @@ trait ModelGenerators {
   implicit val arbitrarySubmissionDetails: Arbitrary[SubmissionDetails] = Arbitrary {
     for {
       fileName        <- nonEmptyString
-      fileSize        <- arbitrary[Long]
+      fileSize        <- arbitrary[Long].suchThat(_ >= 0)
       fileChecksum    <- nonEmptyString
       enrolmentId     <- nonEmptyString
       uploadId        <- nonEmptyString
       documentUrl     <- nonEmptyString
       messageSpecData <- arbitrary[MessageSpecData]
-    } yield SubmissionDetails(fileName, UploadId(uploadId), enrolmentId, fileSize, documentUrl, fileChecksum, messageSpecData)
+      fileReference   <- arbitrary[Reference]
+    } yield SubmissionDetails(fileName, UploadId(uploadId), enrolmentId, fileSize, documentUrl, fileChecksum, messageSpecData, fileReference)
   }
 
   def listWithMaxLength[T](maxSize: Int, gen: Gen[T]): Gen[Seq[T]] =

--- a/test/controllers/SendYourFileControllerSpec.scala
+++ b/test/controllers/SendYourFileControllerSpec.scala
@@ -23,11 +23,12 @@ import generators.Generators
 import models.fileDetails.BusinessRuleErrorCode.{DocRefIDFormat, InvalidMessageRefIDFormat}
 import models.fileDetails._
 import models.submission.SubmissionDetails
+import models.upscan.Reference
 import models.{ConversationId, NewInformation, UserAnswers, ValidatedFileData}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import pages.{ConversationIdPage, URLPage, UploadIDPage, ValidXMLPage}
+import pages.{ConversationIdPage, FileReferencePage, URLPage, UploadIDPage, ValidXMLPage}
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -93,6 +94,7 @@ class SendYourFileControllerSpec extends SpecBase with Generators with ScalaChec
               .withPage(ValidXMLPage, fileData)
               .withPage(URLPage, submissionDetails.documentUrl)
               .withPage(UploadIDPage, submissionDetails.uploadId)
+              .withPage(FileReferencePage, submissionDetails.fileReference)
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
               .overrides(bind[SubmissionConnector].toInstance(mockSubmissionConnector))
@@ -145,6 +147,7 @@ class SendYourFileControllerSpec extends SpecBase with Generators with ScalaChec
               .withPage(ValidXMLPage, fileData)
               .withPage(URLPage, submissionDetails.documentUrl)
               .withPage(UploadIDPage, submissionDetails.uploadId)
+              .withPage(FileReferencePage, submissionDetails.fileReference)
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
               .overrides(bind[SubmissionConnector].toInstance(mockSubmissionConnector))


### PR DESCRIPTION
…can audit submissions of failed, rejected or quarantines files