### PR TITLE
DAC6-3750 | CBC: implement 'Some information is missing' in file upload for file issues

### DIFF
--- a/app/controllers/CheckYourFileDetailsController.scala
+++ b/app/controllers/CheckYourFileDetailsController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import viewmodels.CheckYourFileDetailsViewModel
 import viewmodels.govuk.summarylist._
-import views.html.{CheckYourFileDetailsView, ThereIsAProblemView}
+import views.html.{CheckYourFileDetailsView, SomeInformationMissingView}
 
 import javax.inject.Inject
 
@@ -39,7 +39,7 @@ class CheckYourFileDetailsController @Inject() (
   requireData: DataRequiredAction,
   val controllerComponents: MessagesControllerComponents,
   view: CheckYourFileDetailsView,
-  errorView: ThereIsAProblemView
+  errorView: SomeInformationMissingView
 ) extends FrontendBaseController
     with I18nSupport
     with Logging {
@@ -54,7 +54,7 @@ class CheckYourFileDetailsController @Inject() (
           Ok(view(detailsList))
         case _ =>
           logger.warn("CheckYourFileDetailsController: Unable to retrieve XML information from UserAnswers")
-          InternalServerError(errorView())
+          InternalServerError(errorView(routes.UploadFileController.onPageLoad().url))
       }
   }
 

--- a/app/controllers/CheckYourFileDetailsController.scala
+++ b/app/controllers/CheckYourFileDetailsController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import viewmodels.CheckYourFileDetailsViewModel
 import viewmodels.govuk.summarylist._
-import views.html.{CheckYourFileDetailsView, SomeInformationMissingView}
+import views.html.CheckYourFileDetailsView
 
 import javax.inject.Inject
 
@@ -38,8 +38,7 @@ class CheckYourFileDetailsController @Inject() (
   getData: DataRetrievalAction,
   requireData: DataRequiredAction,
   val controllerComponents: MessagesControllerComponents,
-  view: CheckYourFileDetailsView,
-  errorView: SomeInformationMissingView
+  view: CheckYourFileDetailsView
 ) extends FrontendBaseController
     with I18nSupport
     with Logging {
@@ -54,7 +53,7 @@ class CheckYourFileDetailsController @Inject() (
           Ok(view(detailsList))
         case _ =>
           logger.warn("CheckYourFileDetailsController: Unable to retrieve XML information from UserAnswers")
-          InternalServerError(errorView(routes.UploadFileController.onPageLoad().url))
+          Redirect(routes.FileProblemSomeInformationMissingController.onPageLoad())
       }
   }
 

--- a/app/controllers/FileProblemSomeInformationMissingController.scala
+++ b/app/controllers/FileProblemSomeInformationMissingController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.SomeInformationMissingView
+
+import javax.inject.Inject
+
+class FileProblemSomeInformationMissingController @Inject() (
+  override val messagesApi: MessagesApi,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  val controllerComponents: MessagesControllerComponents,
+  view: SomeInformationMissingView
+) extends FrontendBaseController
+    with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData() andThen requireData) {
+    implicit request =>
+      Ok(view(routes.UploadFileController.onPageLoad().url))
+  }
+}

--- a/app/controllers/SendYourFileController.scala
+++ b/app/controllers/SendYourFileController.scala
@@ -29,7 +29,6 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import repositories.SessionRepository
-import uk.gov.hmrc.hmrcfrontend.controllers.routes
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.FileProblemHelper.isProblemStatus
 import viewmodels.SendYourFileViewModel

--- a/app/controllers/SendYourFileController.scala
+++ b/app/controllers/SendYourFileController.scala
@@ -118,7 +118,7 @@ class SendYourFileController @Inject() (
 
   private def fastJourneyErrorRoute(errors: FileValidationErrors, result: Future[Result]): Future[Result] =
     if (isProblemStatus(errors)) {
-      Future.successful(Ok(Json.toJson(URL(routes.FileProblemSomeInformationMissingController.onPageLoad().url))))
+      Future.successful(Ok(Json.toJson(URL(routes.FileProblemController.onPageLoad().url))))
     } else {
       result
     }

--- a/app/controllers/SendYourFileController.scala
+++ b/app/controllers/SendYourFileController.scala
@@ -84,7 +84,7 @@ class SendYourFileController @Inject() (
             case _ => Future.successful(InternalServerError)
           }
         case (None, _, _, _) =>
-          Future.successful(Redirect(controllers.routes.FileProblemSomeInformationMissingController.onPageLoad()))
+          Future.successful(Redirect(routes.FileProblemSomeInformationMissingController.onPageLoad()))
         case _ =>
           Future.successful(InternalServerError)
       }
@@ -96,18 +96,18 @@ class SendYourFileController @Inject() (
         case Some(conversationId) =>
           fileDetailsConnector.getStatus(conversationId) flatMap {
             case Some(FileStatusAccepted) =>
-              Future.successful(Ok(Json.toJson(URL(controllers.routes.FileReceivedController.onPageLoad(conversationId).url))))
+              Future.successful(Ok(Json.toJson(URL(routes.FileReceivedController.onPageLoad(conversationId).url))))
             case Some(Rejected(errors)) =>
               fastJourneyErrorRoute(
                 errors,
-                Future.successful(Ok(Json.toJson(URL(controllers.routes.FileRejectedController.onPageLoad(conversationId).url))))
+                Future.successful(Ok(Json.toJson(URL(routes.FileRejectedController.onPageLoad(conversationId).url))))
               )
             case Some(Pending) =>
               Future.successful(NoContent)
             case Some(RejectedSDES) =>
-              Future.successful(Ok(Json.toJson(URL(controllers.routes.ThereIsAProblemController.onPageLoad().url))))
+              Future.successful(Ok(Json.toJson(URL(routes.ThereIsAProblemController.onPageLoad().url))))
             case Some(RejectedSDESVirus) =>
-              Future.successful(Ok(Json.toJson(URL(controllers.routes.FileProblemVirusController.onPageLoad().url))))
+              Future.successful(Ok(Json.toJson(URL(routes.FileProblemVirusController.onPageLoad().url))))
             case None =>
               logger.warn("getStatus: no status returned")
               Future.successful(InternalServerError)
@@ -120,7 +120,7 @@ class SendYourFileController @Inject() (
 
   private def fastJourneyErrorRoute(errors: FileValidationErrors, result: Future[Result]): Future[Result] =
     if (isProblemStatus(errors)) {
-      Future.successful(Ok(Json.toJson(URL(controllers.routes.FileProblemSomeInformationMissingController.onPageLoad().url))))
+      Future.successful(Ok(Json.toJson(URL(routes.FileProblemSomeInformationMissingController.onPageLoad().url))))
     } else {
       result
     }

--- a/app/controllers/SendYourFileController.scala
+++ b/app/controllers/SendYourFileController.scala
@@ -83,8 +83,6 @@ class SendYourFileController @Inject() (
               } yield Redirect(controllers.routes.FilePendingChecksController.onPageLoad())
             case _ => Future.successful(InternalServerError)
           }
-        case (None, _, _, _) =>
-          Future.successful(Redirect(routes.FileProblemSomeInformationMissingController.onPageLoad()))
         case _ =>
           Future.successful(InternalServerError)
       }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -94,6 +94,8 @@ GET        /problem/information-sent                                            
 
 GET        /problem/some-information-is-missing                                 controllers.SomeInformationMissingController.onPageLoad()
 
+GET        /problem/upload-file/some-information-is-missing                     controllers.FileProblemSomeInformationMissingController.onPageLoad()
+
 GET        /upload-file                                                         controllers.UploadFileController.onPageLoad()
 
 GET        /status                                                              controllers.UploadFileController.getStatus(uploadId: upscan.UploadId)

--- a/test/controllers/CheckYourFileDetailsControllerSpec.scala
+++ b/test/controllers/CheckYourFileDetailsControllerSpec.scala
@@ -88,8 +88,7 @@ class CheckYourFileDetailsControllerSpec extends SpecBase {
       }
     }
 
-    "must return internal server error when there is no ValidXMLPage in request" in {
-      val uploadUrlPath   = routes.UploadFileController.onPageLoad().url
+    "must redirect to file problem missing information page when there is no ValidXMLPage in request" in {
       val ua: UserAnswers = emptyUserAnswers
 
       val application = new GuiceApplicationBuilder()
@@ -103,8 +102,6 @@ class CheckYourFileDetailsControllerSpec extends SpecBase {
       val request = FakeRequest(GET, routes.CheckYourFileDetailsController.onPageLoad().url)
 
       val result = route(application, request).value
-
-      val view = application.injector.instanceOf[SomeInformationMissingView]
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.FileProblemSomeInformationMissingController.onPageLoad().url

--- a/test/controllers/CheckYourFileDetailsControllerSpec.scala
+++ b/test/controllers/CheckYourFileDetailsControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import viewmodels.CheckYourFileDetailsViewModel
 import viewmodels.govuk.summarylist._
-import views.html.CheckYourFileDetailsView
+import views.html.{CheckYourFileDetailsView, SomeInformationMissingView}
 
 class CheckYourFileDetailsControllerSpec extends SpecBase {
 
@@ -88,5 +88,26 @@ class CheckYourFileDetailsControllerSpec extends SpecBase {
       }
     }
 
+    "must return internal server error when there is no ValidXMLPage in request" in {
+      val uploadUrlPath   = routes.UploadFileController.onPageLoad().url
+      val ua: UserAnswers = emptyUserAnswers
+
+      val application = new GuiceApplicationBuilder()
+        .overrides(
+          bind[DataRequiredAction].to[DataRequiredActionImpl],
+          bind[IdentifierAction].to[FakeIdentifierActionAgent],
+          bind[DataRetrievalAction].toInstance(new FakeDataRetrievalActionProvider(Some(ua)))
+        )
+        .build()
+
+      val request = FakeRequest(GET, routes.CheckYourFileDetailsController.onPageLoad().url)
+
+      val result = route(application, request).value
+
+      val view = application.injector.instanceOf[SomeInformationMissingView]
+
+      status(result) mustEqual INTERNAL_SERVER_ERROR
+      contentAsString(result) mustEqual view(uploadUrlPath)(request, messages(application)).toString
+    }
   }
 }

--- a/test/controllers/CheckYourFileDetailsControllerSpec.scala
+++ b/test/controllers/CheckYourFileDetailsControllerSpec.scala
@@ -106,8 +106,8 @@ class CheckYourFileDetailsControllerSpec extends SpecBase {
 
       val view = application.injector.instanceOf[SomeInformationMissingView]
 
-      status(result) mustEqual INTERNAL_SERVER_ERROR
-      contentAsString(result) mustEqual view(uploadUrlPath)(request, messages(application)).toString
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual routes.FileProblemSomeInformationMissingController.onPageLoad().url
     }
   }
 }

--- a/test/controllers/FileProblemSomeInformationMissingControllerSpec.scala
+++ b/test/controllers/FileProblemSomeInformationMissingControllerSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.SomeInformationMissingView
+
+class FileProblemSomeInformationMissingControllerSpec extends SpecBase {
+
+  "FileProblem SomeInformation missing Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.FileProblemSomeInformationMissingController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[SomeInformationMissingView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(routes.UploadFileController.onPageLoad().url)(request, messages(application)).toString
+      }
+    }
+  }
+}

--- a/test/controllers/SendYourFileControllerSpec.scala
+++ b/test/controllers/SendYourFileControllerSpec.scala
@@ -130,23 +130,6 @@ class SendYourFileControllerSpec extends SpecBase with Generators with ScalaChec
         }
       }
 
-      "redirect to 'file problem some information missing' page when userAnswers missing" in {
-
-        val userAnswers = emptyUserAnswers
-
-        val application = applicationBuilder(userAnswers = Some(userAnswers))
-          .build()
-
-        running(application) {
-          val request = FakeRequest(POST, routes.SendYourFileController.onSubmit().url)
-
-          val result = route(application, request).value
-
-          status(result) mustEqual SEE_OTHER
-          redirectLocation(result).value mustEqual routes.FileProblemSomeInformationMissingController.onPageLoad().url
-        }
-      }
-
       "return INTERNAL_SERVER_ERROR on failing to submit document" in {
         forAll {
           submissionDetails: SubmissionDetails =>

--- a/test/controllers/SendYourFileControllerSpec.scala
+++ b/test/controllers/SendYourFileControllerSpec.scala
@@ -81,11 +81,7 @@ class SendYourFileControllerSpec extends SpecBase with Generators with ScalaChec
 
         running(application) {
           val request   = FakeRequest(GET, routes.SendYourFileController.onPageLoad().url)
-          val appConfig = application.injector.instanceOf[FrontendAppConfig]
-
           val result = route(application, request).value
-
-          val view = application.injector.instanceOf[SendYourFileView]
 
           status(result) mustEqual SEE_OTHER
           redirectLocation(result).value mustEqual routes.FileProblemSomeInformationMissingController.onPageLoad().url

--- a/test/controllers/SendYourFileControllerSpec.scala
+++ b/test/controllers/SendYourFileControllerSpec.scala
@@ -80,8 +80,8 @@ class SendYourFileControllerSpec extends SpecBase with Generators with ScalaChec
         val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
         running(application) {
-          val request   = FakeRequest(GET, routes.SendYourFileController.onPageLoad().url)
-          val result = route(application, request).value
+          val request = FakeRequest(GET, routes.SendYourFileController.onPageLoad().url)
+          val result  = route(application, request).value
 
           status(result) mustEqual SEE_OTHER
           redirectLocation(result).value mustEqual routes.FileProblemSomeInformationMissingController.onPageLoad().url

--- a/test/controllers/SendYourFileControllerSpec.scala
+++ b/test/controllers/SendYourFileControllerSpec.scala
@@ -348,7 +348,7 @@ class SendYourFileControllerSpec extends SpecBase with Generators with ScalaChec
           val result = route(application, request).value
 
           status(result) mustEqual OK
-          contentAsString(result) must include(routes.FileProblemSomeInformationMissingController.onPageLoad().url)
+          contentAsString(result) must include(routes.FileProblemController.onPageLoad().url)
         }
       }
 

--- a/test/controllers/SendYourFileControllerSpec.scala
+++ b/test/controllers/SendYourFileControllerSpec.scala
@@ -323,7 +323,7 @@ class SendYourFileControllerSpec extends SpecBase with Generators with ScalaChec
         }
       }
 
-      "must return OK and load the page 'Missing Information' when the file status is 'Rejected' with 'problem' errors" in {
+      "must return OK and load the page 'problem page' when the file status is 'Rejected' with 'problem' errors" in {
 
         val mockFileDetailsConnector = mock[FileDetailsConnector]
         val validationErrors = FileValidationErrors(Some(Seq(FileErrors(UnknownErrorCode("unknown-error"), None))),


### PR DESCRIPTION
Ticket: https://jira.tools.tax.service.gov.uk/browse/DAC6-3750
1. Updated SendYourFileController#pageload, #onSubmit and #getStatus to redirect to missing information page if file is missing or file fails schema validation.
2.  Updated CheckYourFileDetailsController#pageLoad to render missing page when file is not present in the request