### PR TITLE
DAC6-3750 | bug fix for scenario whereby you upload an invalid xml f…le after uploading a valid xml file and calling the /send-file endpoint

### DIFF
--- a/app/controllers/UploadFileController.scala
+++ b/app/controllers/UploadFileController.scala
@@ -24,7 +24,7 @@ import models.requests.DataRequest
 import models.upscan._
 import org.apache.pekko
 import org.apache.pekko.actor.ActorSystem
-import pages.{FileReferencePage, UploadIDPage}
+import pages.{FileReferencePage, UploadIDPage, ValidXMLPage}
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/actions/CheckForSubmissionAction.scala
+++ b/app/controllers/actions/CheckForSubmissionAction.scala
@@ -36,10 +36,9 @@ class CheckForSubmissionActionProvider @Inject() (checkFileSubmission: Boolean)(
     extends ActionRefiner[DataRequest, DataRequest] {
 
   override protected def refine[A](request: DataRequest[A]): Future[Either[Result, DataRequest[A]]] =
-    if (
-      (checkFileSubmission && request.userAnswers.get(UploadIDPage).isEmpty && request.userAnswers.get(FileReferencePage).isEmpty) ||
-      (!checkFileSubmission && request.userAnswers.get(JourneyInProgressPage).isEmpty)
-    ) {
+    if (checkFileSubmission && request.userAnswers.get(UploadIDPage).isEmpty && request.userAnswers.get(FileReferencePage).isEmpty) {
+      Future.successful(Left(Redirect(routes.FileProblemSomeInformationMissingController.onPageLoad())))
+    } else if (!checkFileSubmission && request.userAnswers.get(JourneyInProgressPage).isEmpty) {
       Future.successful(Left(Redirect(routes.InformationSentController.onPageLoad())))
     } else {
       Future.successful(Right(request))

--- a/app/pages/InvalidXMLPage.scala
+++ b/app/pages/InvalidXMLPage.scala
@@ -16,12 +16,22 @@
 
 package pages
 
+import models.UserAnswers
 import play.api.libs.json.JsPath
+import scala.util.Try
 
 case object InvalidXMLPage extends QuestionPage[String] {
 
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "invalidXML"
+
+  override def cleanup(value: Option[String], userAnswers: UserAnswers): Try[UserAnswers] =
+    value match {
+      case Some(_) =>
+        userAnswers
+          .remove(ValidXMLPage)
+      case _ => super.cleanup(value, userAnswers)
+    }
 
 }

--- a/app/pages/ValidXMLPage.scala
+++ b/app/pages/ValidXMLPage.scala
@@ -16,8 +16,10 @@
 
 package pages
 
-import models.ValidatedFileData
+import models.{UserAnswers, ValidatedFileData}
 import play.api.libs.json.JsPath
+
+import scala.util.Try
 
 case object ValidXMLPage extends QuestionPage[ValidatedFileData] {
 
@@ -25,4 +27,11 @@ case object ValidXMLPage extends QuestionPage[ValidatedFileData] {
 
   override def toString: String = "validXML"
 
+  override def cleanup(value: Option[ValidatedFileData], userAnswers: UserAnswers): Try[UserAnswers] =
+    value match {
+      case Some(_) =>
+        userAnswers
+          .remove(InvalidXMLPage)
+      case _ => super.cleanup(value, userAnswers)
+    }
 }

--- a/test/controllers/actions/CheckForSubmissionActionSpec.scala
+++ b/test/controllers/actions/CheckForSubmissionActionSpec.scala
@@ -74,7 +74,7 @@ class CheckForSubmissionActionSpec extends SpecBase with EitherValues {
         val result = action.callRefine(DataRequest(FakeRequest(), "id", "subscriptionId", Organisation, emptyUserAnswers)).map(_.left.value)
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result).value mustEqual routes.InformationSentController.onPageLoad().url
+        redirectLocation(result).value mustEqual routes.FileProblemSomeInformationMissingController.onPageLoad().url
       }
     }
 

--- a/test/pages/InvalidXMLPageSpec.scala
+++ b/test/pages/InvalidXMLPageSpec.scala
@@ -16,6 +16,7 @@
 
 package pages
 
+import models.{CBC401, MessageSpecData, TestData, UserAnswers, ValidatedFileData}
 import pages.behaviours.PageBehaviours
 
 class InvalidXMLPageSpec extends PageBehaviours {
@@ -26,5 +27,20 @@ class InvalidXMLPageSpec extends PageBehaviours {
     beSettable[String](InvalidXMLPage)
 
     beRemovable[String](InvalidXMLPage)
+
+    "when invalid xml page is set" - {
+      "it should remove valid xml page from user answers" in {
+        val messageSpec             = MessageSpecData("messageRefId", CBC401, "Reporting Entity", TestData)
+        val validateFileData        = ValidatedFileData("filename.xml", messageSpec, 0L, "checksum")
+        val validXMLPageUserAnswers = UserAnswers("some-id").set(ValidXMLPage, validateFileData).success.value
+
+        validXMLPageUserAnswers.get(ValidXMLPage).isDefined mustEqual true
+
+        val invalidXMLPageUserAnswers = validXMLPageUserAnswers.set(InvalidXMLPage, "some-xml").success.value
+        invalidXMLPageUserAnswers.get(ValidXMLPage).isEmpty mustEqual true
+        invalidXMLPageUserAnswers.get(InvalidXMLPage).isDefined mustEqual true
+      }
+
+    }
   }
 }

--- a/test/pages/ValidXMLPageSpec.scala
+++ b/test/pages/ValidXMLPageSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import models.{CBC401, MessageSpecData, TestData, UserAnswers, ValidatedFileData}
+import pages.behaviours.PageBehaviours
+
+class ValidXMLPageSpec extends PageBehaviours {
+
+  "ValidXmlPage" - {
+    "must remove invalid xml page when validXmlPage is set" in {
+      val userAnswerWithInvalidXml = UserAnswers("some-user-id").set(InvalidXMLPage, "some-xml").success.value
+
+      userAnswerWithInvalidXml.get(InvalidXMLPage).isDefined mustEqual true
+
+      val messageSpec             = MessageSpecData("messageRefId", CBC401, "Reporting Entity", TestData)
+      val validatedFileData       = ValidatedFileData("filename.xml", messageSpec, 0L, "checksum")
+      val userAnswersWithValidXml = userAnswerWithInvalidXml.set(ValidXMLPage, validatedFileData).success.value
+
+      userAnswersWithValidXml.get(InvalidXMLPage).isEmpty mustEqual true
+      userAnswersWithValidXml.get(ValidXMLPage).isDefined mustEqual true
+    }
+  }
+}


### PR DESCRIPTION
**Ticket**: https://jira.tools.tax.service.gov.uk/browse/DAC6-3750

**Description:**
The change is to address an issue that occurs when you upload a valid xml file then do another upload with an invalid xml file then call the /send-file endpoint. Instead of returning a missing information page, it sends the valid xml from the first upload. I have made a change that will display the missing information error page.

