### PR TITLE
DAC63750 | Remove valid xml Page from the session when UploadFileController#onPageLoad. [Bug fix]

### DIFF
--- a/app/controllers/UploadFileController.scala
+++ b/app/controllers/UploadFileController.scala
@@ -24,7 +24,7 @@ import models.requests.DataRequest
 import models.upscan._
 import org.apache.pekko
 import org.apache.pekko.actor.ActorSystem
-import pages.{FileReferencePage, UploadIDPage}
+import pages.{FileReferencePage, UploadIDPage, ValidXMLPage}
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -71,6 +71,7 @@ class UploadFileController @Inject() (
         request.userAnswers
           .set(UploadIDPage, uploadId)
           .flatMap(_.set(FileReferencePage, upscanInitiateResponse.fileReference))
+          .flatMap(_.remove(ValidXMLPage))
       )
       _ <- sessionRepository.set(updatedAnswers)
     } yield Ok(view(preparedForm, upscanInitiateResponse)))

--- a/test/controllers/UploadFileControllerSpec.scala
+++ b/test/controllers/UploadFileControllerSpec.scala
@@ -97,7 +97,7 @@ class UploadFileControllerSpec extends SpecBase with ScalaCheckPropertyChecks wi
         answers: UserAnswers =>
           answers.get(FileReferencePage).isDefined &&
           answers.get(UploadIDPage).isDefined &&
-          !(answers.get(ValidXMLPage).isDefined)
+          answers.get(ValidXMLPage).isEmpty
       })
     }
 


### PR DESCRIPTION
Ticket: https://jira.tools.tax.service.gov.uk/browse/DAC6-3750
Removing a valid xml page from the session when UploadFileController#onPageLoad is called. This is to ensure they are no lingering xml files from an uncompleted file uploaded journey.