### PR TITLE
DAC6-4380 | fixed different client contact detail persisting on agent…

### DIFF
--- a/app/pages/AgentIsThisYourClientPage.scala
+++ b/app/pages/AgentIsThisYourClientPage.scala
@@ -17,6 +17,7 @@
 package pages
 
 import models.UserAnswers
+import models.subscription.ContactTypePage
 import play.api.libs.json.JsPath
 
 import scala.util.Try
@@ -32,6 +33,20 @@ case object AgentIsThisYourClientPage extends QuestionPage[Boolean] {
       case Some(false) =>
         userAnswers
           .remove(AgentClientIdPage)
-      case _ => super.cleanup(value, userAnswers)
+      case Some(true) =>
+        userAnswers
+          .remove(ContactTypePage.primaryContactDetailsPages.contactNamePage)
+          .flatMap(_.remove(ContactTypePage.primaryContactDetailsPages.contactTelephonePage))
+          .flatMap(_.remove(ContactTypePage.primaryContactDetailsPages.haveTelephonePage))
+          .flatMap(_.remove(ContactTypePage.primaryContactDetailsPages.contactEmailPage))
+          .flatMap(_.remove(ContactTypePage.primaryContactDetailsPages.contactEmailPage))
+          .flatMap(_.remove(HaveSecondContactPage))
+          .flatMap(_.remove(ReviewClientContactDetailsPage))
+          .flatMap(_.remove(ContactTypePage.secondaryContactDetailsPages.contactNamePage))
+          .flatMap(_.remove(ContactTypePage.secondaryContactDetailsPages.contactTelephonePage))
+          .flatMap(_.remove(ContactTypePage.secondaryContactDetailsPages.haveTelephonePage))
+          .flatMap(_.remove(ContactTypePage.secondaryContactDetailsPages.contactEmailPage))
+      case None => super.cleanup(value, userAnswers)
+
     }
 }

--- a/app/viewmodels/govuk/ButtonFluency.scala
+++ b/app/viewmodels/govuk/ButtonFluency.scala
@@ -27,7 +27,6 @@ trait ButtonFluency {
 
     def apply(content: Content): Button =
       Button(
-        element = Some("button"),
         content = content
       )
   }
@@ -36,7 +35,6 @@ trait ButtonFluency {
 
     def asLink(href: String): Button =
       Button(
-        element = Some("a"),
         href = Some(href),
         name = button.name,
         inputType = button.inputType,
@@ -51,7 +49,6 @@ trait ButtonFluency {
 
     def asInput(inputType: String): Button =
       Button(
-        element = Some("input"),
         inputType = Some(inputType),
         href = button.href,
         name = button.name,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "10.7.0"
+  private val bootstrapVersion = "10.8.0"
   private val hmrcMongoVersion = "2.12.0"
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.32.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "13.9.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.5.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,

--- a/test/controllers/CheckYourFileDetailsControllerSpec.scala
+++ b/test/controllers/CheckYourFileDetailsControllerSpec.scala
@@ -60,21 +60,23 @@ class CheckYourFileDetailsControllerSpec extends SpecBase {
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[CheckYourFileDetailsView]
-
-        val list = SummaryListViewModel(CheckYourFileDetailsViewModel.getSummaryRows(vfd)(messages(application)))
-          .withoutBorders()
-          .withCssClass("govuk-!-margin-bottom-0")
-
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(list)(request, messages(application)).toString
       }
     }
 
     "must return OK and the correct view for a GET for Agent" in {
 
-      val ua: UserAnswers = userAnswersWithContactDetails
+      val ua: UserAnswers = emptyUserAnswers
         .withPage(AgentIsThisYourClientPage, true)
+        .withPage(ContactNamePage, "test")
+        .withPage(ContactEmailPage, "test@test.com")
+        .withPage(HaveTelephonePage, true)
+        .withPage(ContactPhonePage, "6677889922")
+        .withPage(HaveSecondContactPage, true)
+        .withPage(SecondContactNamePage, "test user")
+        .withPage(SecondContactEmailPage, "t2@test.com")
+        .withPage(SecondContactHavePhonePage, true)
+        .withPage(SecondContactPhonePage, "8889988728")
         .withPage(AgentFirstContactNamePage, "test")
         .withPage(AgentFirstContactEmailPage, "test@test.com")
         .withPage(AgentFirstContactHavePhonePage, false)
@@ -92,21 +94,38 @@ class CheckYourFileDetailsControllerSpec extends SpecBase {
         val request = FakeRequest(GET, routes.CheckYourFileDetailsController.onPageLoad().url)
 
         val result = route(application, request).value
-
-        val view = application.injector.instanceOf[CheckYourFileDetailsView]
-
-        val list = SummaryListViewModel(CheckYourFileDetailsViewModel.getAgentSummaryRows(vfd)(messages(application)))
-          .withoutBorders()
-          .withCssClass("govuk-!-margin-bottom-0")
-
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(list)(request, messages(application)).toString
+        contentType(result) mustBe Some("text/html")
+        charset(result) mustBe Some("utf-8")
+
+        val body = contentAsString(result)
+
+        body must include("Check your file details are correct")
+        body must include("File ID (MessageRefId)")
+        body must include("Client (ReportingEntity Name)")
+        body must include("File information")
+        body must include("Test data")
+        body must include("""href="/send-a-country-by-country-report/upload-file"""")
+        body must include("""href="/send-a-country-by-country-report/send-your-file"""")
+        body must include("""id="submit"""")
+        body must include("""id="your-file"""")
+
       }
     }
 
     "must redirect to file problem missing information page when there is no ValidXMLPage in request" in {
 
-      val userAnswers = userAnswersWithContactDetails
+      val userAnswers = emptyUserAnswers
+        .withPage(AgentIsThisYourClientPage, true)
+        .withPage(ContactNamePage, "test")
+        .withPage(ContactEmailPage, "test@test.com")
+        .withPage(HaveTelephonePage, true)
+        .withPage(ContactPhonePage, "6677889922")
+        .withPage(HaveSecondContactPage, true)
+        .withPage(SecondContactNamePage, "test user")
+        .withPage(SecondContactEmailPage, "t2@test.com")
+        .withPage(SecondContactHavePhonePage, true)
+        .withPage(SecondContactPhonePage, "8889988728")
         .withPage(AgentIsThisYourClientPage, true)
         .withPage(AgentFirstContactNamePage, "test")
         .withPage(AgentFirstContactEmailPage, "test@test.com")
@@ -126,7 +145,7 @@ class CheckYourFileDetailsControllerSpec extends SpecBase {
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
-      redirectLocation(result).value mustEqual routes.FileProblemSomeInformationMissingController.onPageLoad().url
+      redirectLocation(result).value must include("some-information-is-missing")
     }
 
     "must redirect to Agent Some Info missing information page when there is no agent contact in request" in {

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -69,11 +69,19 @@ class IndexControllerSpec extends SpecBase {
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[IndexView]
-
         status(result) mustEqual OK
+        contentType(result) mustBe Some("text/html")
 
-        contentAsString(result) mustEqual view(showRecentFiles = false, "subscriptionId", isAgent = false)(request, messages(application)).toString
+        val body = contentAsString(result)
+
+        body must include("Manage your country-by-country report")
+        body must include("You can report new information, or corrections and deletions, by uploading an XML file.")
+        body must include("The file must include your CBC ID subscriptionId and be 100MB or less.")
+        body must include("""href="/send-a-country-by-country-report/upload-file"""")
+        body must include("""id="submit"""")
+        body must include("Upload an XML file")
+        body must include("""href="/send-a-country-by-country-report/change-contact/details"""")
+        body must include("change your contact details")
       }
     }
 


### PR DESCRIPTION
Live issue:
if an agent changed CBC id from a non-migrated -> migrated client, the contact details from client 1 (non migrated) was saved/displayed on CYA
This ticket completes the relevant clear up to avoid this happening moving forward by removing all client contact detail once agents change in between clients