### PR TITLE
AC6-4396 | CBC: Fix for Special characters in filename/MessageRefId are shown as HTML entities in file upload

### DIFF
--- a/app/viewmodels/CheckYourFileDetailsViewModel.scala
+++ b/app/viewmodels/CheckYourFileDetailsViewModel.scala
@@ -17,12 +17,12 @@
 package viewmodels
 
 import controllers.routes
-import models._
+import models.*
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.summarylist._
+import viewmodels.govuk.summarylist.*
 
 object CheckYourFileDetailsViewModel {
 
@@ -31,7 +31,7 @@ object CheckYourFileDetailsViewModel {
     Seq(
       SummaryListRowViewModel(
         key = "checkYourFileDetails.messageRefId",
-        value = ValueViewModel(HtmlFormat.escape(s"${specData.messageRefId}").toString),
+        value = ValueViewModel(HtmlContent(HtmlFormat.escape(specData.messageRefId))),
         actions = Seq()
       ),
       SummaryListRowViewModel(

--- a/app/viewmodels/FileReceivedViewModel.scala
+++ b/app/viewmodels/FileReceivedViewModel.scala
@@ -19,6 +19,7 @@ package viewmodels
 import models.fileDetails.FileDetails
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{SummaryList, SummaryListRow}
 import viewmodels.govuk.summarylist._
 
@@ -28,7 +29,7 @@ object FileReceivedViewModel {
     Seq(
       SummaryListRowViewModel(
         key = "fileReceived.messageRefId.key",
-        value = ValueViewModel(HtmlFormat.escape(s"${receivedFileDetails.messageRefId}").toString),
+        value = ValueViewModel(HtmlContent(HtmlFormat.escape(receivedFileDetails.messageRefId))),
         actions = Seq()
       ),
       SummaryListRowViewModel(

--- a/test/views/components/CheckYourFileDetailsViewSpec.scala
+++ b/test/views/components/CheckYourFileDetailsViewSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import base.SpecBase
+import models.{CBC401, CorrectionForExistingReport, MessageSpecData, ValidatedFileData}
+import org.jsoup.Jsoup
+import play.api.i18n.{Lang, Messages}
+import play.api.mvc.{AnyContent, MessagesControllerComponents}
+import play.api.test.{FakeRequest, Injecting}
+import utils.ViewHelper
+import viewmodels.CheckYourFileDetailsViewModel
+import viewmodels.govuk.all.SummaryListViewModel
+import views.html.{CheckYourFileDetailsView, FileErrorView}
+
+class CheckYourFileDetailsViewSpec extends SpecBase with Injecting with ViewHelper {
+  implicit private val request: FakeRequest[AnyContent] = FakeRequest()
+
+  private def setupDoc = {
+    val validatedFileData: ValidatedFileData = ValidatedFileData(
+      fileName = "testFi",
+      fileSize = 1234,
+      messageSpecData = MessageSpecData(
+        messageRefId = "test'RefId",
+        messageTypeIndic = CBC401,
+        reportType = CorrectionForExistingReport,
+        reportingPeriodStartDate = java.time.LocalDate.of(2024, 1, 1),
+        reportingPeriodEndDate = java.time.LocalDate.of(2024, 12, 31),
+        reportingEntityName = "Test Entity"
+      ),
+      checksum = "some-checksum"
+    )
+    val view: CheckYourFileDetailsView                                    = inject[CheckYourFileDetailsView]
+    val messagesControllerComponentsForView: MessagesControllerComponents = inject[MessagesControllerComponents]
+    implicit val messages: Messages                                       = messagesControllerComponentsForView.messagesApi.preferred(Seq(Lang("en")))
+    val summaryList = SummaryListViewModel(CheckYourFileDetailsViewModel.getAgentSummaryRows(validatedFileData))
+
+    Jsoup.parse(view(summaryList).body)
+  }
+
+  "CheckYourFileDetailsView" - {
+    "should render page components" in {
+      val doc = setupDoc
+
+      getWindowTitle(doc) must include("Check your file details are correct")
+
+      doc.select(".govuk-summary-list__row").get(0).select(".govuk-summary-list__key").text() must include("File ID (MessageRefId)")
+      doc.select(".govuk-summary-list__row").get(0).select(".govuk-summary-list__value").text() must include(
+        "test'RefId"
+      )
+
+      doc.select(".govuk-summary-list__row").get(1).select(".govuk-summary-list__key").text() must include("Client (ReportingEntity Name)")
+      doc.select(".govuk-summary-list__row").get(1).select(".govuk-summary-list__value").text() must include(
+        "Test Entity"
+      )
+
+      doc.select(".govuk-summary-list__row").get(2).select(".govuk-summary-list__key").text() must include("File information")
+      doc.select(".govuk-summary-list__row").get(2).select(".govuk-summary-list__value").text() must include(
+        "Corrections for an existing report"
+      )
+
+    }
+  }
+}


### PR DESCRIPTION
Check your file Page:
<img width="1476" height="787" alt="Screenshot 2026-07-06 at 13 16 56" src="https://github.com/user-attachments/assets/0f0b3303-8651-4c87-b775-3bbc788f1c30" />

File Confirmation Page:
<img width="1279" height="1048" alt="Screenshot 2026-07-06 at 13 17 23" src="https://github.com/user-attachments/assets/987faebe-b518-435d-bb19-759001f3c12a" />
